### PR TITLE
Makefile: various fixes for install rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BATCH=$(EMACS) -batch -q -no-site-file -eval                             			\
 ELC= $(BATCH) -f batch-byte-compile
 
 # How to copy the lisp files and elc files to their distination.
-CP = cp -p
+CP = install -m 644
 
 ##----------------------------------------------------------------------
 ##  BELOW THIS LINE ON YOUR OWN RISK!
@@ -43,13 +43,11 @@ default: $(ELCFILES)
 install: install-lisp
 
 install-lisp: $(LISPFILES) $(ELCFILES)
-	if [ ! -d $(lispdir) ]; then $(MKDIR) $(lispdir); else true; fi ;
-	$(CP) $(LISPFILES)  $(lispdir)
-	$(CP) $(ELCFILES)   $(lispdir)
+	install -d -m 755 $(DESTDIR)$(lispdir)
+	$(CP) $(LISPFILES) $(DESTDIR)$(lispdir)
+	$(CP) $(ELCFILES) $(DESTDIR)$(lispdir)
 
-clean:
-	${MAKE} cleanelc
-
+clean: cleanelc
 cleanelc:
 	rm -f $(ELCFILES)
 

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ CP = install -m 644
 ##----------------------------------------------------------------------
 
 # The following variables need to be defined by the maintainer
-LISPF      = 	rebox2.el	 	\
+LISPFILES   = 	rebox2.el	 	\
 
-ELCFILES    = $(LISPF:.el=.elc)
+ELCFILES    = $(LISPFILES:.el=.elc)
 
 default: $(ELCFILES)
 


### PR DESCRIPTION
- use the common variable DESTDIR to install to a temporary directory.
  - use install rather than cp/mkdir
